### PR TITLE
bugfix - optional decimals were not being correctly decoded

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -38,7 +38,7 @@ func ExampleDecoder_Decode_reflection() {
 		FieldByID   string  `fast:"15"`   // assign value by instruction id
 		FieldByName string  `fast:"Test"` // assign value by instruction name
 		Equal       int32   			  // name of field is default value for assign
-		Nullable    *uint64 `fast:"20"`   // nullable - will skip, if field data is absent
+		Nullable    *uint64 `fast:"20"`   // nullable
 		Skip        int     `fast:"-"`    // skip
 		Sequence    []Seq
 	}
@@ -92,7 +92,7 @@ func ExampleEncoder_Encode_reflection() {
 		FieldByID   string  `fast:"15"`   // assign value by instruction id
 		FieldByName string  `fast:"Test"` // assign value by instruction name
 		Equal       int32   			  // name of field is default value for assign
-		Nullable    *uint64 `fast:"20"`   // nullable - will skip, if field data is absent
+		Nullable    *uint64 `fast:"20"`   // nullable
 		Skip        int     `fast:"-"`    // skip
 		Sequence    []Seq
 	}
@@ -117,5 +117,5 @@ func ExampleEncoder_Encode_reflection() {
 	}
 	fmt.Printf("%x", buf.Bytes())
 
-	// Output: c081746573f4808182
+	// Output: c081746573f480808182
 }

--- a/fast_test.go
+++ b/fast_test.go
@@ -9,11 +9,12 @@ import (
 )
 
 type decimalType struct {
-	TemplateID           uint `fast:"*"`
-	CopyDecimal          float64
-	MandatoryDecimal     float64
-	IndividualDecimal    float64
-	IndividualDecimalOpt float64
+	TemplateID                        uint `fast:"*"`
+	CopyDecimal                       float64
+	MandatoryDecimal                  float64
+	IndividualDecimal                 float64
+	IndividualDecimalOpt              float64
+	IndividualDecimalOptExpNotPresent (*float64)
 }
 
 type sequenceType struct {
@@ -106,7 +107,7 @@ type benchmarkReceiver struct {
 	benchmarkMessage
 
 	seqLocked bool
-	seqIndex int
+	seqIndex  int
 }
 
 func (br *benchmarkReceiver) SetTemplateID(tid uint) {
@@ -198,13 +199,14 @@ func (br *benchmarkReceiver) SetValue(field *fast.Field) {
 }
 
 var (
-	decimalData1    = []byte{0xf8, 0x81, 0xfe, 0x4, 0x83, 0xff, 0xc, 0x8a, 0xfc, 0xa0, 0xff, 0x0, 0xef}
+	decimalData1    = []byte{0xfc, 0x81, 0xfe, 0x4, 0x83, 0xff, 0xc, 0x8a, 0xfc, 0xa0, 0xff, 0x0, 0xef, 0x80}
 	decimalMessage1 = decimalType{
-		TemplateID:           1,
-		CopyDecimal:          5.15,
-		MandatoryDecimal:     154.6,
-		IndividualDecimal:    0.0032,
-		IndividualDecimalOpt: 11.1,
+		TemplateID:                        1,
+		CopyDecimal:                       5.15,
+		MandatoryDecimal:                  154.6,
+		IndividualDecimal:                 0.0032,
+		IndividualDecimalOpt:              11.1,
+		IndividualDecimalOptExpNotPresent: (*float64)(nil),
 	}
 
 	value      uint32 = 2

--- a/instruction.go
+++ b/instruction.go
@@ -15,7 +15,7 @@ type Instruction struct {
 	Value        interface{}
 
 	pMapSize int
-	key   string
+	key      string
 }
 
 func (i *Instruction) isValid() bool {
@@ -281,9 +281,12 @@ func (i *Instruction) read(reader *reader) (result interface{}, err error) {
 }
 
 func (i *Instruction) injectDecimal(writer *writer, s storage, pmap *pMap, value interface{}) (err error) {
-	mantissa, exponent := newMantExp(value.(float64))
+	var mantissa, exponent interface{}
+	if value != nil {
+		mantissa, exponent = newMantExp(value.(float64))
+	}
 	for _, in := range i.Instructions {
-		if in.Type == TypeMantissa {
+		if in.Type == TypeMantissa && value != nil {
 			err = in.inject(writer, s, pmap, mantissa)
 			if err != nil {
 				return
@@ -315,6 +318,9 @@ func (i *Instruction) extractDecimal(reader *reader, s storage, pmap *pMap) (int
 			eField, err := in.extract(reader, s, pmap)
 			if err != nil {
 				return nil, err
+			}
+			if eField == nil {
+				return nil, nil
 			}
 			exponent = eField.(int32)
 		}

--- a/instruction.go
+++ b/instruction.go
@@ -320,7 +320,7 @@ func (i *Instruction) extractDecimal(reader *reader, s storage, pmap *pMap) (int
 				return nil, err
 			}
 			if eField == nil {
-				return nil, nil
+				return nil, err
 			}
 			exponent = eField.(int32)
 		}

--- a/testdata/test.xml
+++ b/testdata/test.xml
@@ -19,6 +19,14 @@
                 <delta/>
             </mantissa>
         </decimal>
+        <decimal name="IndividualDecimalOptExpNotPresent" id="5" presence="optional">
+            <exponent>
+                <default value="0"/>
+            </exponent>
+            <mantissa>
+                <delta/>
+            </mantissa>
+        </decimal>
     </template>
 
     <template name="Sequence" id="2" xmlns="http://www.fixprotocol.org/ns/fast/td/1.1">


### PR DESCRIPTION
When using goFAST to decode a stream, I noticed problems when decoding an optional decimal field with individual operators.

Looking at the FAST spec, I saw in sec 10.5.1 this:

If the decimal has optional presence, the exponent field is treated as an optional integer field and
the mantissa field is treated as a mandatory integer field. The presence of the mantissa field and
any related bits in the presence map are dependent on the presence of the exponent. The
mantissa field appears in the stream iff the exponent value is considered present. If the mantissa
has an operator that requires a bit in the presence map, this bit is present iff the exponent value is
considered present.

I made changes to the decimal decoding/encoding logic to reflect the possibility that it is not present.
I also had to change the reflector to allow encoding and decoding of nullable fields.

Tests are passing... 
However I'm no expert in FAST encoding and I'm a beginner Go programmer. I did my best...
